### PR TITLE
Change `version` update checking method in CircleCI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ RUN sudo apt-get remove --yes mercurial mercurial-common \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
   && sudo apt-get update -qq \
   && sudo apt-get install --yes git yarn \
+  && sudo npm install --global npm \
   && sudo apt-get autoremove --yes \
   && sudo apt-get clean
-
-# TODO Update npm when this issue is fixed: https://github.com/npm/npm/issues/15558
-# RUN sudo npm install --global npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM circleci/node
 
-RUN sudo apt-get update -qq \
+RUN sudo apt-get remove --yes mercurial mercurial-common \
+  && sudo apt-get update -qq \
   && sudo apt-get dist-upgrade --yes \
   && sudo apt-get install --yes git \
+  && sudo apt-get autoremove --yes \
   && sudo apt-get clean
 
 # TODO Update npm when this issue is fixed: https://github.com/npm/npm/issues/15558

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,11 @@ FROM circleci/node
 RUN sudo apt-get remove --yes mercurial mercurial-common \
   && sudo apt-get update -qq \
   && sudo apt-get dist-upgrade --yes \
-  && sudo apt-get install --yes git \
+  && sudo apt-get install --yes apt-transport-https \
+  && sudo curl --silent --show-error https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
+  && sudo apt-get update -qq \
+  && sudo apt-get install --yes git yarn \
   && sudo apt-get autoremove --yes \
   && sudo apt-get clean
 

--- a/circle.yml
+++ b/circle.yml
@@ -33,20 +33,50 @@ jobs:
 
       - deploy:
           command: |
-            if [[ -n "${CIRCLE_TAG}" ]]; then
-              check_version () {
-                local linter="$1"
+            if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
+              #
+              # If this build is pull request, check if `version` in package.json
+              # is bumped up correctly in case config.[js|ts] is/are updated.
+              #
 
-                NEW_VERSION="$(cat "$SCRIPT_DIR/$linter-config/package.json" | jq --raw-output ".version")"
-                if [[ -n "$(npm view "@phanect/$linter-config-phanective@$NEW_VERSION")" ]]; then
-                  echo -e "$RED@phanect/$linter-config-phanective@$NEW_VERSION already exists. Did you update version in package.json?$NC\n" > /dev/stderr
-                  exit 1
+              # Check if config.[js|ts] is updated in this pull request
+              CONFIG_UPDATED="false"
+              PR_NUMBER="$(echo "$CIRCLE_PULL_REQUEST" | cut --delimiter="/" --fields=7)"
+
+              MODIFIED_FILES="$(curl --silent "https://api.github.com/repos/phanect/eslint-config-phanective/pulls/${PR_NUMBER}/files" | jq --raw-output ".[] | .filename")"
+
+              for MODIFIED_FILE in $MODIFIED_FILES; do
+                if [[ "$MODIFIED_FILE" = "eslint-config/config.js" ]]; then
+                  CONFIG_UPDATED="true"
+                  break;
                 fi
-              }
 
-              check_version "eslint"
-              check_version "tslint"
+                if [[ "$MODIFIED_FILE" = "tslint-config/config.ts" ]]; then
+                  CONFIG_UPDATED="true"
+                  break;
+                fi
+              done
 
+              # In case config.[js|ts] is/are updated, check if `version` in package.json is/are updated
+
+              if [[ "$CONFIG_UPDATED" = "true" ]]; then
+                check_version () {
+                  local linter="$1"
+
+                  NEW_VERSION="$(cat $HOME/eslint-config-phanective/$linter-config/package.json | jq --raw-output ".version")"
+                  if [[ -n "$(npm view "@phanect/$linter-config-phanective@$NEW_VERSION")" ]]; then
+                    echo -e "$RED@phanect/$linter-config-phanective@$NEW_VERSION already exists. Did you update version in package.json?$NC\n" > /dev/stderr
+                    exit 1
+                  fi
+                }
+
+                check_version "eslint"
+                check_version "tslint"
+              fi
+            elif [[ "${CIRCLE_BRANCH}" = "master" ]]; then
+              #
+              # If this build is master branch, deploy to npmjs.com
+              #
               git clean -dX --force # Remove files written in .gitignore so they are not included in package
 
               echo -e "phanect\n$NPM_PASSWORD\n$NPM_EMAIL" | npm login
@@ -55,4 +85,7 @@ jobs:
 
               npm publish ./eslint-config --access public
               npm publish ./tslint-config --access public
+            else
+              echo "Something unexpected happened" > /dev/stderr
+              exit 1
             fi


### PR DESCRIPTION
Change method to confirm if `version` in package.json is updated on each PRs.

1.0. If this build is pull request, check if config.[js|ts] is/are updated in the pull request
1.1. If config.[js|ts] is/are updated, check if `version` in package.json is/are updated. If not, the build fails.
2.0. If this build is done on master branch, deploy package to npmjs.com.